### PR TITLE
Rewording of Technical Groups page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -228,7 +228,7 @@
                                 <a href="http://foundation.fsharp.org/member_roster">Member Roster</a>
                             </li>
                             <li>
-                                <a href="/technical-groups">Affiliated technical groups</a>
+                                <a href="/technical-groups">Technical groups</a>
                             </li>
                             <li>
                                 <a href="http://fsharp.github.io">F# Core Engineering Group</a>

--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
                                 <a href="http://foundation.fsharp.org/member_roster">Member Roster</a>
                             </li>
                             <li>
-                                <a href="/technical-groups">Affiliated technical groups</a>
+                                <a href="/technical-groups">Technical groups</a>
                             </li>
                             <li>
                                 <a href="http://fsharp.github.io">F# Core Engineering Group</a>

--- a/technical-groups/index.md
+++ b/technical-groups/index.md
@@ -1,25 +1,13 @@
 ---
 layout: page
 title: The F# Software Foundation
-headline: Affiliated Technical Groups
+headline: Technical Groups
 ---
 
+The F# Software Foundation members actively seek to encourage and facilitate community operated F# related meetups,
+discussion groups, as well as working groups directly affiliated with the foundation. 
 
-The F# Software Foundation members actively seek to encourage and facilitate F#-related meetups,
-discussion groups and working groups affiliated with the foundation. 
-
-Any F#-related group can be affiliated with the FSSF, including both professional and open-source groups,
-and those associated with 3rd-party commercial technologies.
-
-The current affiliated technical groups are:
-
- * [**Community for F#**](http://c4fsharp.net) (contact Mathias Brandewinder and Ryan Riley)
- * [**F# Web Programming Group**](https://groups.google.com/forum/#!forum/web-stack-fs) (contact Ryan Riley)
- * [**F# for Data and Machine Learning**](https://groups.google.com/forum/#!forum/fsharp-data-science) (contact Mathias Brandewinder)
- * **F# in Finance** (contact Natallie Baikevich)
- * **F# in Academia** (contact Antonio Cisternino)
-
-Two technical groups are closely associated with the F# Software Foundation's mission:
+The following Working Groups are directly affiliated with the F# Software Foundation:
 
  * [**F# Core Engineering**](http://fsharp.github.io) (contact Michael Newton or Dave Thomas)  
  * **F# Software Foundation Communications Group** (contact [fsharp@fsharp.org](mailto:fsharp@fsharp.org))
@@ -27,5 +15,12 @@ Two technical groups are closely associated with the F# Software Foundation's mi
 More details of the working groups can be found by contacting the people above or 
 emailing [fsharp@fsharp.org](mailto:fsharp@fsharp.org). 
 
-We encourage groups to adopt a public presence and [submit an edit to this page](https://github.com/fsharp/fsfoundation/edit/gh-pages/technical-groups/index.md) with details (GitHub login required).
+Current communitiy operated technical groups which fit with [the mission](http://foundation.fsharp.org) include:
 
+ * [**Community for F#**](http://c4fsharp.net) (contact Mathias Brandewinder and Ryan Riley)
+ * [**F# Web Programming Group**](https://groups.google.com/forum/#!forum/web-stack-fs) (contact Ryan Riley)
+ * [**F# for Data and Machine Learning**](https://groups.google.com/forum/#!forum/fsharp-data-science) (contact Mathias Brandewinder)
+ * **F# in Finance** (contact Natallie Baikevich)
+ * **F# in Academia** (contact Antonio Cisternino)
+
+We encourage community operated groups to adopt a public presence and [submit an edit to this page](https://github.com/fsharp/fsfoundation/edit/gh-pages/technical-groups/index.md) with details (GitHub login required).


### PR DESCRIPTION
Removed "affiliation" language for non-affiliated groups for legal reasons.