### PR TITLE
Add icon for external links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,6 +28,7 @@
     <link href="http://netdna.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" media="screen" />
     <link href='http://fonts.googleapis.com/css?family=Rajdhani' rel='stylesheet' type='text/css' />
     <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css' />
+    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/main.css" media="screen" />
 
     <!--[if lt IE 9]>

--- a/css/main.css
+++ b/css/main.css
@@ -512,14 +512,30 @@ div#contentMain.testimonials ul li {
     margin: 30px;
 }
 
-    .calloutBox h1 {
-        font-size: 180%;
-        margin: 10px 10px 10px 0px;
-    }
+.calloutBox h1 {
+    font-size: 180%;
+    margin: 10px 10px 10px 0px;
+}
 
-    .calloutBox p {
-        font-size: 100%;
-        margin: 0px 0px 6px 0px;
-        line-height: normal;
-        padding: 0px;
-    }
+.calloutBox p {
+    font-size: 100%;
+    margin: 0px 0px 6px 0px;
+    line-height: normal;
+    padding: 0px;
+}
+
+a[href^="http://"]:after, a[href^="https://"]:after {
+  content: "\f08e";
+  font-family: FontAwesome;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 12px;
+  display: inline-block;
+  text-decoration: none;
+  padding-left: 7px;
+}
+
+a[href^="http://fsharp.org"]:after, a[href^="https://github.com/fsharp"]:after, a.no_icon:after {
+  content:"" !important;
+  padding-left: 0;
+}


### PR DESCRIPTION
As we are moving towards formal F# Foundation structure, it is important to distinguish what is original F# org content and what are external links. This uses a neat CSS trick to make this visible:

![links](https://cloud.githubusercontent.com/assets/485413/5856267/804031ec-a239-11e4-9a35-c738c67b706f.png)
