### PR TITLE
Added a link to Aivika for .NET

### DIFF
--- a/community/projects/index.md
+++ b/community/projects/index.md
@@ -382,5 +382,9 @@ Contributions welcome!
 * [MITIE-Dot-Net](https://github.com/BayardRock/MITIE-Dot-Net/blob/master/README.md) - A Nice .NET Wrapper for the MITIE Information Extraction Library (Written in F#, but fully C# compatible)
 
 
+<br />
 
+<h2 class="anchor" id="textsearch" class="anchor">Community Projects: Simulation Tools</h2>
+
+*  [Aivika for .NET](https://github.com/dsorokin/aivika-fsharp-ce) - A simulation library for discrete event simulation, system dynamics and agent-based modeling.
 


### PR DESCRIPTION
Hi! 

Please add a link to my simulation library Aivika for .NET. This is an F# port of my Haskell simulation library of the same name. It supports discrete event simulation, system dynamics and agent-based modeling. The library is released under a dual-license model: GPLv3 and Commercial. There is the PDF documentation, but it mostly describes a commercial version, although the engine itself is fully licensed under dual GPL/Commercial. The commercial version contains only additional modules that are needed for analysis of the results.

Thanks,
David Sorokin