### PR TITLE
add sonarqube f# plugin

### DIFF
--- a/community/projects/index.md
+++ b/community/projects/index.md
@@ -72,6 +72,8 @@ Contributions welcome!
 
 *  ![logo](/images/thumbs/FSharpLint.png)&nbsp;[FSharpLint](https://github.com/fsprojects/FSharpLint) - A lint tool for F#.
 
+*  [F# SonarQube Plugin](https://github.com/jmecosta/sonar-fsharp-plugin) - F# support for SonarQube
+
 <br />
 
 


### PR DESCRIPTION
hi,

ive created a plugin for sonarqube that allows the import f# code, it uses fsharplint and fxcop.

Would it be possible to list it in the foundantion

Thanks and Regards
Jorge Costa