### PR TITLE
Update index.md

### DIFF
--- a/use/windows/index.md
+++ b/use/windows/index.md
@@ -9,7 +9,7 @@ headline: Use F# on Windows
 
 ![logo](/images/thumbs/vstudio.png)&nbsp;On Windows, F# programmers commonly use the Visual F# Tools from Microsoft.
 
-*  Install the free [Visual Studio 2013 Community](http://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx); if you already have Visual Studio 2013 Professional or above, you can use that.  Visual Studio 2013 Community and above come with the Visual F# Tools. 
+* Install the free [Visual Studio 2015 Community](http://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx); if you already have Visual Studio 2013 Professional or above, you can use that.  Visual Studio 2013 Community and above come with the Visual F# Tools. 
 
 The Visual F# Tools include the command-line compiler (`fsc.exe`) and F# Interactive (`fsi.exe`).
 See [Visual F# Resources](http://msdn.microsoft.com/en-us/vstudio/hh388569.aspx) for more information about the Visual F# Tools from Microsoft.
@@ -17,7 +17,7 @@ See [Visual F# Resources](http://msdn.microsoft.com/en-us/vstudio/hh388569.aspx)
 #### ![logo](/images/thumbs/FSharpVSPowerTools.png)&nbsp;[Visual F# Power Tools](http://fsprojects.github.io/VisualFSharpPowerTools/) ####
 
 Optionally, install the community-provided [Visual F# Power Tools](http://fsprojects.github.io/VisualFSharpPowerTools/),
-for use with Visual Studio 2012 and 2013 (Community or higher, not Express, see above). They include [source code formatting](http://fsprojects.github.io/VisualFSharpPowerTools/codeformatting.html), 
+for use with Visual Studio 2013 and 2015 (Community or higher, not Express, see above). They include [source code formatting](http://fsprojects.github.io/VisualFSharpPowerTools/codeformatting.html), 
 [auto-generating XML Docs](http://fsprojects.github.io/VisualFSharpPowerTools/xmldoc.html), 
 [navigation bar](http://fsprojects.github.io/VisualFSharpPowerTools/navbar.html), 
 [highlight](http://fsprojects.github.io/VisualFSharpPowerTools/highlightusage.html) and [find](http://fsprojects.github.io/VisualFSharpPowerTools/findallreferences.html) references, 
@@ -47,11 +47,15 @@ following requirements and installation steps:
 
 1. Requires .NET 4.5:
 
+   - On Windows 10 .NET 4.6 is already present by default
+
    - On Windows 8 and Windows 2012 Server, this is already present by default
    
    - On Windows 7 and Windows 2008 Server, [install .NET 4.5](http://www.microsoft.com/net/downloads) from Microsoft
 
 2. Requires the Windows SDK:
+
+   - On Windows 10 use the [Windows 10 and .NET 4.6 SDK](https://dev.windows.com/en-US/downloads/windows-10-sdk) from Microsoft
 
    - On Windows 8.1 use the [Windows 8.1 and .NET 4.5.1 SDK](http://msdn.microsoft.com/windows/desktop/bg162891) from Microsoft
    
@@ -70,9 +74,9 @@ following requirements and installation steps:
 
 The compiler tools are installed at
 
-    C:\Program Files (x86)\Microsoft SDKs\F#\3.1\Framework\v4.0\fsc.exe
-    C:\Program Files (x86)\Microsoft SDKs\F#\3.1\Framework\v4.0\fsi.exe
-    C:\Program Files (x86)\Microsoft SDKs\F#\3.1\Framework\v4.0\fsiAnyCpu.exe
+    C:\Program Files (x86)\Microsoft SDKs\F#\4.0\Framework\v4.0\fsc.exe
+    C:\Program Files (x86)\Microsoft SDKs\F#\4.0\Framework\v4.0\fsi.exe
+    C:\Program Files (x86)\Microsoft SDKs\F#\4.0\Framework\v4.0\fsiAnyCpu.exe
     
 If you're looking for Visual F# Tools 3.0 specifically, its standalone version could be downloaded [here](http://go.microsoft.com/fwlink/?LinkId=261286). 
     

--- a/use/windows/index.md
+++ b/use/windows/index.md
@@ -63,12 +63,12 @@ following requirements and installation steps:
    
    - On Windows 7 or Windows 2008 Server use the [Windows 7 and .NET 4.0 SDK](http://www.microsoft.com/download/details.aspx?id=8279) from Microsoft
    
-3. [Install the free Visual F# Tools 3.1.2](http://www.microsoft.com/download/details.aspx?id=44011) from Microsoft
+3. [Install the free Visual F# Tools 4.0](https://www.microsoft.com/en-us/download/details.aspx?id=48179) from Microsoft
 
    Alternatively, do a quiet install from a PowerShell administrator prompt (the URL is the redirect of the above). 
 
         $webclient = New-Object Net.WebClient
-        $url = 'http://download.microsoft.com/download/E/A/3/EA38D9B8-E00F-433F-AAB5-9CDA28BA5E7D/FSharp_Bundle.exe'
+        $url = 'http://download.microsoft.com/download/9/1/2/9122D406-F1E3-4880-A66D-D6C65E8B1545/FSharp_Bundle.exe'
         $webclient.DownloadFile($url, "$pwd\FSharp_Bundle.exe")
         .\FSharp_Bundle.exe /install /quiet
 
@@ -90,7 +90,7 @@ The recommended procedure is to bundle this component with your final applicatio
 
 The *Visual F# Tools* downloads from Microsoft installs FSharp.Core.dll into GAC, as well as the command-line tools *fsc* (the F# compiler) and *fsi* (F# Interactive).
 
-- [Visual F# Tools 3.1.2](http://www.microsoft.com/en-us/download/details.aspx?id=44011)
+- [Visual F# Tools 4.0](https://www.microsoft.com/en-us/download/details.aspx?id=48179)
 
 ### Option 5: Build F# from source
 


### PR DESCRIPTION
Update references to VS2015, F# 4.0 and Windows 10

I'm not sure I'm consistent in this. I left the reference to F# Tools 3.1.2 since 4.0 is RTM. But some of the other chances I made might be for 4.0, so might be wrong.