### PR TITLE
Added F# on Slack page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -196,6 +196,9 @@
                             </li>
                             <li>
                                 <a href="http://chat.stackoverflow.com/rooms/51909/f">F# StackOverflow Chat</a>
+                            </li>
+                            <li>
+                                <a href="/guides/slack">F# on Slack</a>
                             </li>
                         </ul>
                     </li>

--- a/guides/slack/index.md
+++ b/guides/slack/index.md
@@ -1,0 +1,41 @@
+---
+layout: default
+title: Guide - F# on Slack | The F# Software Foundation
+headline: Guide - F# Slack Teams
+---
+
+[Slack](https://slack.com/) is a persistent chat service. Some of its features are:
+
+* Persistence - No need to be continually logged in
+* Searchable chat history - For large Slacks this is limited to 10 days or so
+* [Link Sharing](https://slack.zendesk.com/hc/en-us/articles/204399343-Sharing-links-in-Slack) - For example linked images can be automatically shown
+* [Message Formatting](https://slack.zendesk.com/hc/en-us/articles/202288908-Formatting-your-messages)
+* [Message editing](https://slack.zendesk.com/hc/en-us/articles/202395258-Editing-or-deleting-messages) - you can correct message typos or delete them entirely
+* [File](https://slack.zendesk.com/hc/en-us/articles/201330736-Uploading-and-sharing-files) and [text snippet](https://slack.zendesk.com/hc/en-us/articles/204145658-Creating-a-Snippet) sharing
+* Privacy - Unlike [freenode](https://freenode.net/) IP addresses are not publicly visible
+
+## Functional Programming Slack Team
+
+To get an invite to the [Functional Programming
+Slack](https://functionalprogramming.slack.com/) team visit
+[fpchat.com](http://fpchat.com). An invitation will be sent to the email
+address you supply. Follow the instructions to join the Functional
+Programming Slack team.
+
+There are currently two F# related channels in the Functional Programming Slack:
+
+* [#fsharp](https://functionalprogramming.slack.com/?redir=/archives/fsharp) - This is the general channel for F#. The developers of [Visual F# Power Tools](https://fsprojects.github.io/VisualFSharpPowerTools/), [Xamarin Studio](https://developer.xamarin.com/guides/cross-platform/fsharp/fsharp_support_overview/), [Ionide](http://ionide.io/), [SqlProvider](http://fsprojects.github.io/SQLProvider/), among others all hang out here and are very active. The channel can be wildly off-topic for hours at a time but specific F# questions are usually answered fairly quickly.
+
+* [#fsharp-beginners](https://functionalprogramming.slack.com/archives/fsharp-beginners) - Since the main F# channel can be a bit overwhelming, this channel was created to be a bit more friendly for those new to F#.
+
+Other channels that may be of interest are #haskell, #haskell-beginners, #categorytheory, and #scala.
+
+## F# Software Foundation Slack Team
+
+Only members of the F# Software Foundation can be invited to this team. To join visit [this page](http://foundation.fsharp.org/join).
+
+Once you are a member send an email to info@fsharp.org to get an invite to the Slack team.
+
+<div class="jumbotron visible-lg calloutBox" id="how-to-add-testimonial"> 
+    <p>This guide includes resources related to F# Slack teams. To contribute to this guide, log on to GitHub, <a href="https://github.com/fsharp/fsfoundation/edit/gh-pages/guides/slack/index.md">edit this page</a> and send a pull request.</p>
+</div>              

--- a/guides/slack/index.md
+++ b/guides/slack/index.md
@@ -32,7 +32,7 @@ Other channels that may be of interest include: #haskell, #haskell-beginners, #c
 
 ## F# Software Foundation Slack Team
 
-Only members of the F# Software Foundation can be invited to this team. To join visit [this page](http://foundation.fsharp.org/join).
+Only members of the F# Software Foundation can be invited to the [F# Software Foundation](https://fsharp.slack.com/) team. To join visit [this page](http://foundation.fsharp.org/join).
 
 Once you are a member send an email to info@fsharp.org to get an invite to the Slack team.
 

--- a/guides/slack/index.md
+++ b/guides/slack/index.md
@@ -26,9 +26,9 @@ There are currently two F# related channels in the Functional Programming Slack:
 
 * [#fsharp](https://functionalprogramming.slack.com/?redir=/archives/fsharp) - This is the general channel for F#. The developers of [Visual F# Power Tools](https://fsprojects.github.io/VisualFSharpPowerTools/), [Xamarin Studio](https://developer.xamarin.com/guides/cross-platform/fsharp/fsharp_support_overview/), [Ionide](http://ionide.io/), [SqlProvider](http://fsprojects.github.io/SQLProvider/), among others all hang out here and are very active. The channel can be wildly off-topic for hours at a time but specific F# questions are usually answered fairly quickly.
 
-* [#fsharp-beginners](https://functionalprogramming.slack.com/archives/fsharp-beginners) - Since the main F# channel can be a bit overwhelming, this channel was created to be a bit more friendly for those new to F#.
+* [#fsharp-beginners](https://functionalprogramming.slack.com/archives/fsharp-beginners) - Since the main F# channel can be a bit overwhelming, this channel was created to be more friendly for those new to F#.
 
-Other channels that may be of interest are #haskell, #haskell-beginners, #categorytheory, and #scala.
+Other channels that may be of interest include: #haskell, #haskell-beginners, #categorytheory, and #scala.
 
 ## F# Software Foundation Slack Team
 

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -198,6 +198,9 @@
                             </li>
                             <li>
                                 <a href="http://chat.stackoverflow.com/rooms/51909/f">F# StackOverflow Chat</a>
+                            </li>
+                            <li>
+                                <a href="/guides/slack">F# on Slack</a>
                             </li>
                         </ul>
                     </li>


### PR DESCRIPTION
Since joining Slack teams is slightly more complicated than a simple link on index.html, I created another page that briefly describes the benefits of Slack, and a link to that page under the Contribute dropdown menu.