### PR TITLE
Fixed unclickable links on mobile devices (negative margin overlays upper content)

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -35,8 +35,7 @@ h4,
 h5 {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 600;
-    padding-top: 70px;
-    margin-top: -70px;
+    margin-top: 0px;
 }
 
 h3 {


### PR DESCRIPTION
Negative margin on H1-H5 headers caused that previous (upper) html content is overlayed by header and links are not clickable on mobile devices.