### PR TITLE
Adjust HTML5 "use" guide

### DIFF
--- a/use/html5/index.md
+++ b/use/html5/index.md
@@ -11,16 +11,7 @@ headline: Using F# for HTML5 Web Applications
 
 <br />
 
-### Option 2: Use FunScript
-
-[FunScript](http://funscript.info/) is a standalone converter from F# to JavaScript. 
-It also offers strongly typed interoperability with any components given a TypeScript signature.
-
-> Note: FunScript is no longer actively maintained.
-
-<br />
-
-### Option 3: Use Fable
+### Option 2: Use Fable
 
 [Fable](https://github.com/fsprojects/Fable) is an F# to JS compiler designed to generate clean
 and standard code in order to maximize interoperability in both ways. It integrates with most
@@ -31,9 +22,10 @@ or mobile with [React native](https://facebook.github.io/react-native/).
 
 <br />
 
-### Option 4: Use F# on the Server with JavaScript, CoffeeScript or TypeScript on the client
+### Option 3: Use F# on the Server with JavaScript, CoffeeScript or TypeScript on the client
 
 You can use F# on the server with JavaScript, CoffeeScript or TypeScript as the front end, in conjunction 
 with modern JS/HTML5 web frameworks. More details at [F# Web Programming](/guides/web/).
+
 
 


### PR DESCRIPTION
I recommend that the "use" guides not include options labelled as not being actively maintained.  The "community/projects" list can include such projects.