### PR TITLE
Remove references to tryfsharp.org

### DIFF
--- a/guides/data-science/index.md
+++ b/guides/data-science/index.md
@@ -33,8 +33,6 @@ Data science also requires strong support for many technologies covered in other
 * [Cloud Programming](/guides/cloud/)
 
 
-[Try F#](http://www.tryfsharp.org/Learn/data-science) contains information and tutorials for learning data science in F#.  
-
 <div class="jumbotron visible-lg calloutBox" id="how-to-add-testimonial"> 
     <p>This guide includes resources related to data science programming and scripting with F#. To contribute to this guide, log on to GitHub, <a href="https://github.com/fsharp/fsfoundation/edit/gh-pages/guides/data-science/index.md">edit this page</a> and send a pull request.</p>
     <hr />

--- a/guides/machine-learning/index.md
+++ b/guides/machine-learning/index.md
@@ -9,10 +9,7 @@ F# is well-suited to machine learning because of its efficient execution, succin
 data access capabilities and scalability. F# has been successfully used by some of the most advanced 
 machine learning teams in the world, including several groups at Microsoft Research.
 
-[Try F#](http://tryfsharp.org/learn) has some introductory machine learning algorithms.
-Further resources related to different aspects of machine learning are below.
-
-Related material also exists in other Guides.  For detailed information, refer to the guides for:
+Other guides contain some material related to machine learning:
 
 * [Math and Statistics](guides/math-and-statistics/)
 * [Data Science](/guides/data-science/)

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
                                 <a href="/about/index.html">About F#</a>
                             </li>
                             <li>
-                                <a href="/about/learning.html">Learning F#</a>
+                                <a href="/learn.html">Learning F#</a>
                             </li>
                             <li>
                                 <a href="/mentorship/index.html">F# Mentorship program</a>
@@ -411,8 +411,7 @@ MailboxProcessor.Start(fun inbox-> async {
                 <div class="col-md-6">
                     <h3><span class="glyphicon glyphicon-pencil"></span> Learn</h3>
                     <ul class="">
-                        <li>Learn F# online with <a href="http://www.tryfsharp.org/Learn" target="_blank" onclick="_gaq.push(['_trackEvent', 'home-learn', 'clicked', 'tryfsharp'])">Try F#</a></li>
-                        <li>Read <a href="/about/learning.html" onclick="_gaq.push(['_trackEvent', 'home-learn', 'clicked', 'books'])">F# books and tutorials</a></li>
+                        <li>Read <a href="/learn.html" onclick="_gaq.push(['_trackEvent', 'home-learn', 'clicked', 'books'])">F# books and tutorials</a></li>
                         <li>Read the <a href="/about/index.html#documentation" onclick="_gaq.push(['_trackEvent', 'home-learn', 'clicked', 'documentation'])">documentation</a></li>
                         <li>Watch <a href="/videos/1" onclick="_gaq.push(['_trackEvent', 'home-learn', 'clicked', 'videos'])">F# videos</a></li>
                     </ul>

--- a/learn.md
+++ b/learn.md
@@ -79,27 +79,6 @@ A range of coding dojos for F# from [Community for F#](http://c4fsharp.net) incl
 Site which allows interactive searches by an F# API. The [F# API Search library](https://github.com/hafuu/FSharpApiSearch) document describes the search formats, which support the standard signature of F# with some extentions.  
 Source code available on [GitHub FSDN](https://github.com/fsdn-projects/FSDN)
 
-<!---
-### [Try F#](http://www.tryfsharp.org)
-
-<img src="/about/files/tryfsharp.jpg" style="float:right;margin:5px 0px 5px 25px;" />
-
-Try F# is an interactive environment where you can
-explore F# in your web browser (on Mac and Windows). It contains a number
-of online tutorials demonstrating the power of F#:
-
-The site requires Silverlight for in-browser execution end editing and these options may not be
-available on all browsers.
-
- * [Getting started in F#](http://www.tryfsharp.org/Learn/getting-started)
- * [Advanced F# Programming](http://www.tryfsharp.org/Learn/advanced-programming)
- * [Data Visualization and Charting](http://www.tryfsharp.org/Learn/data-visualization)
- * [Data Science](http://www.tryfsharp.org/Learn/data-science)
- * [Scientific and Numerical Computing](http://www.tryfsharp.org/Learn/scientific-computing)
- * [Financial Computing](http://www.tryfsharp.org/Learn/financial-computing)
-
---->
-
 <h2 id="courses" class="anchor">F# Courses - General</h2>
 
 ### [Introduction to F#](https://fsharp.tv/courses/fsharp-programming-intro/)

--- a/teaching/index.md
+++ b/teaching/index.md
@@ -31,22 +31,6 @@ The F# compiler and tools are cross-platform and run using .NET on Windows and u
 Mac OS and Linux. F# language is supported in several editors. Aside from the commercial Visual 
 Studio and Xamarin Studio tools, there is an F# mode for Emacs and open-source language binding for MonoDevelop.
 
-
-<h2 id="online-teaching-and-learning" class="anchor">Online Teaching and Learning</h2>
-
-[Try F#](http://www.tryfsharp.org) is an interactive environment where you can
-explore F# in your web browser (on Mac and Windows). It contains a number
-of online tutorials demonstrating the concepts of F#:
-
-<img src="/about/files/tryfsharp.jpg" style="float:right;margin:5px 0px 5px 25px;" />
-
- * [Getting started in F#](http://www.tryfsharp.org/Learn/getting-started)
- * [Advanced F# Programming](http://www.tryfsharp.org/Learn/advanced-programming)
- * [Data Visualization and Charting](http://www.tryfsharp.org/data-visualization)
- * [Data Science](http://www.tryfsharp.org/Learn/data-science)
- * [Scientific and Numerical Computing](http://www.tryfsharp.org/Learn/scientific-computing)
- * [Financial Computing](http://www.tryfsharp.org/Learn/financial-computing)
-
 <h2 id="video-lectures" class="anchor">Video lectures</h2>
 
  * **[Teaching programming language concepts with F#](http://channel9.msdn.com/Tags/peter-sestoft)**


### PR DESCRIPTION
I think it's time to let go of tryfsharp.org. It requires you to install Silverlight, an outdated browser plugin, which may put off potential new F# users.

Ideally the site itself should be updated to not require Silverlight or taken down.