### PR TITLE
Remove the news feed

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -338,6 +338,7 @@ pre {
     margin-bottom: 40px;
 }
 
+/*
 #news-list {
     width: 75%;
 }
@@ -349,6 +350,7 @@ pre {
 #news-rss > img {
     vertical-align: baseline;
 }
+*/
 
 .list-group-item {
     border: none;

--- a/index.html
+++ b/index.html
@@ -487,6 +487,7 @@ MailboxProcessor.Start(fun inbox-> async {
         </div>
     </section>
 
+    <!--
     <section class="home-section light-gray">
         <div class="container featured">
             <h2 class="text-center section-header">
@@ -497,6 +498,7 @@ MailboxProcessor.Start(fun inbox-> async {
             <ul class="list-group wow animated fadeIn animated" id="news-list"></ul>
         </div>
     </section>
+    -->
 
     <section class="home-section" style="border-bottom: none;">
         <div id="supporter-container" style="display:none;" class="container featured">

--- a/js/home.js
+++ b/js/home.js
@@ -1,3 +1,4 @@
+/*
 function feedLoaded(result) {
     if (!result.error) {
         var newsContent = document.getElementById("news-list");
@@ -29,6 +30,7 @@ function feedLoaded(result) {
         }
     }
 }
+*/
 
 function shuffle(array) {
     var currentIndex = array.length, temporaryValue, randomIndex;
@@ -94,6 +96,7 @@ function shuffleTestimonials() {
 }
 
 $(function () {
+    /*
     $.ajax({
         url: 'http://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=10&callback=?&q=http%3A%2F%2Ffpish.net%2Frss%2Fblogs%2Ftag%2F1%2Ff~23',
         dataType: 'json',
@@ -101,6 +104,7 @@ $(function () {
             feedLoaded(data.responseData.feed);
         }
     });
+    */
 
     shuffleSupporters();
     $("#supporter-container").show();


### PR DESCRIPTION
The [news feed](http://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=10&callback=?&q=http%3A%2F%2Ffpish.net%2Frss%2Fblogs%2Ftag%2F1%2Ff~23) seems to be dead and the News section on the front page is empty. Perhaps no news is good news but this doesn't look very good!

Rather than fix it, I suggest removing it and keeping the page lean and to the point.

I think the social media share buttons could be removed too. They give a slightly buzzfeed-y vibe and I doubt anyone actually uses them.