### PR TITLE
Commented out feed entry content

### DIFF
--- a/js/home.js
+++ b/js/home.js
@@ -17,7 +17,7 @@ function feedLoaded(result) {
                 a.href = entry.link;
                 a.target = "_blank"
                 h4.appendChild(a);
-                p.appendChild(document.createTextNode(entry.content.trim()));
+                // p.appendChild(document.createTextNode(entry.content.trim()));
                 li.appendChild(h4);
                 li.appendChild(p);
                 newsContent.appendChild(li);


### PR DESCRIPTION
This was causing large blocks of raw HTML to display in the feed - right now, it should just display the title.