### PR TITLE
Clarify install instructions for VS Code

### DIFF
--- a/use/mac/index.md
+++ b/use/mac/index.md
@@ -24,6 +24,7 @@ supporting [a lot of languages](https://code.visualstudio.com/docs/languages/ove
 F# is supported by the [Ionide](http://ionide.io/) project and is a nice integration.
 
 1. Install [Visual Studio Code](https://code.visualstudio.com/download) for Mac
+1. Install the [latest version of Mono](http://www.mono-project.com/download/#download-mac) from the Mono project or via Homebrew (see option 5 below).
 1. Add Mono `/bin` folder to your `PATH`: `export PATH=$PATH:/Library/Frameworks/Mono.framework/Versions/Current/bin/`. For more info see: [Mono installed on Mac, but not recognized in terminal](http://stackoverflow.com/questions/32542535/mono-installed-on-mac-but-not-recognized-in-terminal)
 1. Go back to VS Code, press `Cmd+P` and enter the following to install the Ionide package.
 


### PR DESCRIPTION
Fixes #592 by clarifying how to install mono, which is a prereq for VS Code