### PR TITLE
Update to the current state (Feb2018)

### DIFF
--- a/use/android/index.md
+++ b/use/android/index.md
@@ -4,24 +4,7 @@ title: Use F# for Android Development | The F# Software Foundation
 headline: Use F# for Android Development
 ---
 
-### Option 1: Build Android Apps using F# + Xamarin Tools 
-
-![logo](/images/thumbs/xamarin-studio.png)&nbsp;![logo](/images/thumbs/vstudio.png)&nbsp;[Xamarin](http://xamarin.com) provide F# tools for  Android and iOS modile development with F#, using either Xamarin Studio or Microsoft Visual Studio.
-
-1. Get the [Visual F# tools for Windows](/use/windows) or [F# Tools for Mac](/use/mac). 
-
-2. Get [Xamarin Studio](http://xamarin.com/download)
-
-You can now create a new F# Android app, e.g. an "F# Honeycomb Application". Build and Debug will deploy to an emulator or device.
-
-Report problems as follows:
-
-* For most issues and discussions, use the Xamarin forums and bug tracker
-* For the F# language binding in Xamarin Studio, see [the F# Binding repository](https://github.com/fsharp/xamarin-monodevelop-fsharp-addin)
-
-<br />
-
-### Option 2: Build F# iOS Apps using JetBrains Rider
+### Option 1: Build F# Android Apps using JetBrains Rider
 
 ![logo](/images/thumbs/rider.png)&nbsp;[JetBrains Rider](https://www.jetbrains.com/rider) is a cross-platform .NET IDE built using IntelliJ and ReSharper technology. It offers support for .NET and .NET Core applications on all platforms.
 
@@ -30,6 +13,21 @@ Report problems as follows:
 3. Get [Xamarin Android](https://www.xamarin.com/platform#android).
 4. Get [Android SDK](https://developer.android.com/studio/index.html#downloads).
 5. Install the [latest version of Mono](http://www.mono-project.com/download/) for your OS.
+
+<br />
+
+### Option 2: Build Android Apps using F# + Xamarin Tools and Visual Studio 
+
+![logo](/images/thumbs/xamarin-studio.png)&nbsp;![logo](/images/thumbs/vstudio.png)&nbsp;[Xamarin](http://xamarin.com) provide F# tools for  Android and iOS modile development with F#, using Microsoft Visual Studio.
+
+1. Get the [Visual F# tools for Windows](/use/windows) or [F# Tools for Mac](/use/mac). 
+
+You can now create a new F# Android app, e.g. an "F# Honeycomb Application". Build and Debug will deploy to an emulator or device.
+
+Report problems as follows:
+
+* For most issues and discussions, use the Xamarin forums and bug tracker
+* For the F# language binding in Xamarin Studio, see [the F# Binding repository](https://github.com/fsharp/xamarin-monodevelop-fsharp-addin)
 
 <br />
 


### PR DESCRIPTION
1) I put the JetBrains option as the first choice, since its cross-platform and follows the spirit of .NET Core and F# by that.
2) Changed the typo "iOS" into "Android"
3) Removed Xamarin Studio, since it is ditched in favour of Visual Studio exclusively.