### PR TITLE
Update the site footer's copyright year from '2017' to '2018'

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -260,7 +260,7 @@
     <!-- Footer -->
     <footer id="footer">
         <div class="container text-center">
-            <p>Copyright © 2012-2017 F# Software Foundation and individual contributors.
+            <p>Copyright © 2012-2018 F# Software Foundation and individual contributors.
             <br/>
             <p>Maintained by F# Software Foundation and the F# community on <a href="https://github.com/fsharp/fsfoundation" target="_blank">GitHub</a>.</p>
         </div>


### PR DESCRIPTION
Resolves #710 