### PR TITLE
Autogen no longer used to build F# from source

### DIFF
--- a/use/linux/index.md
+++ b/use/linux/index.md
@@ -105,7 +105,6 @@ Alternatively there is an overlay available with current versions of various .NE
         sudo apt-get install autoconf libtool pkg-config make git automake
         git clone https://github.com/fsharp/fsharp
         cd fsharp
-        ./autogen.sh --prefix /usr
         make
         sudo make install
 


### PR DESCRIPTION
Since https://github.com/fsharp/fsharp/commit/8a5fa570a0334b073e2ffe8f816b3bf84bdafcee