### PR TITLE
Added a F#+SDL2 demo

### DIFF
--- a/guides/apps-and-games/index.md
+++ b/guides/apps-and-games/index.md
@@ -93,3 +93,5 @@ Mobile.
 * [Tetris](https://github.com/ChrisPritchard/Tetris) - Tetris in F#, Dotnet Core and MonoGame. An exercise in functional, immutable game logic.
 
 * [MiniKnight](https://github.com/ChrisPritchard/MiniKnight) - A 2D platformer in F#, Dotnet Core and MonoGame. Pixel graphics, music and sound effects included!
+
+* [Tiny Ray Caster](https://github.com/ChrisPritchard/tiny-ray-caster) - A SDL2-powered Wolfenstein 3D-esque drawing demo, using pure F#, SDL2 and nothing else. A good example of raw F# interop with C libraries.


### PR DESCRIPTION
@ReedCopsey I thought this might be a valuable example to add. SDL2 direct from F# is quite neat :) And a lot lower friction (subjectively) than using a larger framework, like MonoGame or Unity.