### PR TITLE
Update the footer year for generated markdown

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -242,7 +242,7 @@
     <!-- Footer -->
     <footer id="footer">
         <div class="container text-center">
-            <p>Copyright © 2012-2018 F# Software Foundation and individual contributors.
+            <p>Copyright © 2012-2019 F# Software Foundation and individual contributors.
             <br/>
             <p>Maintained by F# Software Foundation and the F# community on <a href="https://github.com/fsharp/fsfoundation" target="_blank">GitHub</a>.</p>
         </div>


### PR DESCRIPTION
This should fix the year for all markdown-generated templated pages