### PR TITLE
Update link to "Functional Programming with F#"

### DIFF
--- a/teaching/index.md
+++ b/teaching/index.md
@@ -107,7 +107,7 @@ type inference. Each chapter has exercises based on such examples.
   interesting insight.
 
 
-* **[Functional Programming with F#](http://www.idt.mdh.se/kurser/DVA201/)**
+* **[Functional Programming with F#](http://www.idt.mdh.se/kurser/DVA229/)**
   Björn Lisper, Mälardalen University, Sweden
 
   The course gives the students a solid under­standing of functional programming, its appli­cations, 


### PR DESCRIPTION
Link to "Functional Programming with F#" course was broken. Updated with current version of web page.