### PR TITLE
Update for Rider 2020.1

### DIFF
--- a/use/linux/index.md
+++ b/use/linux/index.md
@@ -63,11 +63,7 @@ Ionide works best if you use the .NET CLI to create your projects. You can learn
 
 ![logo](/images/thumbs/rider.png)&nbsp;[JetBrains Rider](https://www.jetbrains.com/rider) is a cross-platform .NET IDE built using IntelliJ and ReSharper technology. It offers support for .NET and .NET Core applications on all platforms.
 
-1. Install [JetBrains Rider](https://www.jetbrains.com/rider/download/) for Mac.
-
-2. Install the [latest version of Mono](https://www.mono-project.com/download/stable/#download-mac).
-
-3. Ensure Mono `/bin` folder is added to your `PATH`: `export PATH=$PATH:/Library/Frameworks/Mono.framework/Versions/Current/bin/`. For more info see: [Mono installed on Mac, but not recognized in terminal](http://stackoverflow.com/questions/32542535/mono-installed-on-mac-but-not-recognized-in-terminal)
+You can install [JetBrains Rider from here](https://www.jetbrains.com/rider/download/).
 
 <br />
 ### Option 4: Build F# from source

--- a/use/mac/index.md
+++ b/use/mac/index.md
@@ -73,11 +73,7 @@ You can learn more at [Get started with F# in Visual Studio for Mac](https://doc
 
 ![logo](/images/thumbs/rider.png)&nbsp;[JetBrains Rider](https://www.jetbrains.com/rider) is a cross-platform .NET IDE built using IntelliJ and ReSharper technology. It offers support for .NET and .NET Core applications on all platforms.
 
-1. Install [JetBrains Rider](https://www.jetbrains.com/rider/download/) for Mac.
-
-2. Install the [latest version of Mono](https://www.mono-project.com/download/stable/#download-mac).
-
-3. Ensure Mono `/bin` folder is added to your `PATH`: `export PATH=$PATH:/Library/Frameworks/Mono.framework/Versions/Current/bin/`. For more info see: [Mono installed on Mac, but not recognized in terminal](http://stackoverflow.com/questions/32542535/mono-installed-on-mac-but-not-recognized-in-terminal)
+You can install [JetBrains Rider from here](https://www.jetbrains.com/rider/download/).
 
 <br />
 


### PR DESCRIPTION
Rider now no longer requires Mono on macOS or Linux