### PR TITLE
Add learning link

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -11,6 +11,11 @@ in the modern enterprise and web applications.
 
 <br />
 
+## [About F#](https://dotnet.microsoft.com/languages/fsharp)
+
+A simple, clear resource explaining what F# is and what it is for, provided by a major commercial contributor to F# and its tooling.
+Learn about the tools for F#, the F# community, using F# with the .NET platform and access getting-started material.
+
 ## Language Reference
 
  * [F# Language Reference](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/) - 

--- a/learn/index.md
+++ b/learn/index.md
@@ -12,6 +12,12 @@ redirect_from:
 
 To learn F# use one of the free online resources or books below.
 
+
+### [F# - An open-source, cross-platform functional programming language for .NET](https://dotnet.microsoft.com/languages/fsharp)
+
+A simple, clear resource explaining what F# is and what it is for, provided by a major commercial contributor to F# and its tooling.
+Learn about the tools for F#, the F# community, using F# with the .NET platform and access getting-started material.
+
 ### [F# for C#, Java or Python developers](http://fsharpforfunandprofit.com/)
 
 <img src="../images/thumbs/IHeartFsharp160.png" style="float:right;margin:5px 0px 5px 25px;" />


### PR DESCRIPTION

@cartermp and I did an assessment last night of all the best core "landing pages" for F# and the traffic they're getting stating from basic searches for things like "Learn F#" on Google.

One thing we noticed is that the really good page https://dotnet.microsoft.com/languages/fsharp is not getting much traffic since there are few links in to it.

This is a good, clear neutrally presented resource that really orients people to the basics of F#'s existence as a modern .NET language. I do think it deserves a higher prominence in the learning and about pages.

This resource does not cover everything and we need to make sure we continue to maintain good balance in the learning material linked here.  But I think it's a good addition given its quality.
