### PR TITLE
Add link to newly generated FSharp.Core API Docs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,6 +63,9 @@
                                 <a href="/about/learning.html">Learning F#</a>
                             </li>
                             <li>
+                                <a href="https://fsprojects.github.io/fsharp-core-api-docs">API Docs</a>
+                            </li>
+                            <li>
                                 <a href="/mentorship/index.html">F# Mentorship Program</a>
                             </li>
                             <li>


### PR DESCRIPTION
Closes #832 by adding a link to the learn menu.