### PR TITLE
remove a repl

### DIFF
--- a/use/browser/index.md
+++ b/use/browser/index.md
@@ -7,30 +7,23 @@ headline: Use F# in the browser
 ### Option 1: [Try F# on try.fsharp.org](https://try.fsharp.org/)
 
 ![logo](../../images/thumbs/tryfsharp.jpg)&nbsp;[TryFSharp](https://try.fsharp.org/) enables you to try F# in an online editor/compiler without having to install anything on your
-computer. It includes example code for many of F#'s basic features. It's based on the  [Fable 2 REPL](https://fable.io/repl/).
+computer. It includes example code for many of F#'s basic features.
 
 <br />
 
-### Option 2: [Try Fable in the REPL](https://fable.io/repl/)
+### Option 2: [Try Fable in the REPL](https://fable.io/repl3/)
 
-![logo](../../images/thumbs/fable.png)&nbsp;[Try Fable in the REPL](https://fable.io/repl/). Fable is a compiler powered by Babel that makes F# a first-class citizen of the JavaScript ecosystem.
-
-<br />
-
-### Option 3: [Try F# in repl.it](https://repl.it/languages/fsharp)
-
-[repl.it](https://repl.it/languages/fsharp) - Code and collaborate,
-without friction. Use our free, collaborative, in-browser IDE to code in 50+ languages — without spending a second on setup.
+![logo](../../images/thumbs/fable.png)&nbsp;[Try Fable in the REPL](https://fable.io/repl3/). Fable is a compiler powered by Babel that makes F# a first-class citizen of the JavaScript ecosystem.
 
 <br />
 
-### Option 4: [Try F# in Bolero](https://tryfsharp.fsbolero.io)
+### Option 3: [Try F# in Bolero](https://tryfsharp.fsbolero.io)
 
 [Try F# in Bolero](https://tryfsharp.fsbolero.io) is an online F# playground running entirely in the browser using WebAssembly. Powered by [Bolero](https://fsbolero.io).
 
 <br />
 
-### Option 5: [Try F# in sharplab.io](https://sharplab.io/)
+### Option 4: [Try F# in sharplab.io](https://sharplab.io/)
 
 [SharpLab](https://sharplab.io/) is a C#/VB/F# compiler playground, allows you to see compiled code including generated assembly code.
 
@@ -39,21 +32,21 @@ without friction. Use our free, collaborative, in-browser IDE to code in 50+ lan
 
 ## Registration required
 
-### Option 6: [Try F# in CloudSharper](https://cloudsharper.com/)
+### Option 5: [Try F# in CloudSharper](https://cloudsharper.com/)
 
 [CloudSharper](https://cloudsharper.com/) is an online web and mobile programming with big data and charting. Registration required.
 
 <br />
 
-### Option 7: [Try F# in Visual Studio Online](https://visualstudio.microsoft.com/services/visual-studio-online/)
+### Option 6: [Try F# in GitHub Codespaces](https://visualstudio.microsoft.com/services/github-codespaces/)
 
-[Visual Studio Online](https://visualstudio.microsoft.com/services/visual-studio-online/) is an online service providing cloud-powered dev environments accessible from anywhere. It includes browser based IDE. F# support in VSO is powered by [Ionide](https://ionide.io/). Registration required, paid service.
+[GitHub Codespaces](https://visualstudio.microsoft.com/services/github-codespaces/) allows you to access cloud-hosted dev environments from Visual Studio Code or your browser.
 
-Easiest way to get started with VSO is going to [Ionide Playground repository](https://github.com/ionide/playground) and clicking `VS Online - Create` button
+Easiest way to get started with Gitpod is going to [Ionide Playground repository](https://github.com/ionide/playground) and clicking `Code - Open with Codespaces`.
 
 <br />
 
-### Option 8: [Try F# in Gitpod](https://www.gitpod.io/)
+### Option 7: [Try F# in Gitpod](https://www.gitpod.io/)
 
 [Gitpod](https://www.gitpod.io/) is an online service providing environments accessible from browser based IDE. F# support in Gitpod is powered by [Ionide](https://ionide.io/). Registration required, paid service, includes free OSS plan.
 

--- a/use/web-apps/index.md
+++ b/use/web-apps/index.md
@@ -16,7 +16,7 @@ not only web apps but also [node.js](https://nodejs.org/en/), desktop with [Elec
 or mobile with [React native](https://facebook.github.io/react-native/).
 
 * [Getting Started](https://fable.io/docs/2-steps/setup.html)
-* [Try Online](http://fable.io/repl)
+* [Try Online](http://fable.io/repl3)
 * [Docs](http://fable.io/docs/)
 
 <br />


### PR DESCRIPTION
Removing a REPL that still used Mono 4.5, and had no educational material

Also Visual Studio Online is noe Github Codespaces