### PR TITLE
Draft/RFC: Slight rework

### DIFF
--- a/css/fsdocs-default.css
+++ b/css/fsdocs-default.css
@@ -1,0 +1,604 @@
+@import url('https://fonts.googleapis.com/css2?family=Hind+Vadodara&family=Roboto+Mono&display=swap');
+/*--------------------------------------------------------------------------
+  Formatting for page & standard document content
+/*--------------------------------------------------------------------------*/
+
+body {
+    font-family: 'Hind Vadodara', sans-serif;
+    /*    padding-top: 0px;
+    padding-bottom: 40px;
+*/
+}
+
+blockquote {
+    margin: 0 1em 0 0.25em;
+    margin-top: 0px;
+    margin-right: 1em;
+    margin-bottom: 0px;
+    margin-left: 0.25em;
+    padding: 0 .75em 0 1em;
+    border-left: 1px solid #777;
+    border-right: 0px solid #777;
+}
+
+/* Format the heading - nicer spacing etc. */
+.masthead {
+    overflow: hidden;
+}
+
+    .masthead .muted a {
+        text-decoration: none;
+        color: #999999;
+    }
+
+    .masthead ul, .masthead li {
+        margin-bottom: 0px;
+    }
+
+    .masthead .nav li {
+        margin-top: 15px;
+        font-size: 110%;
+    }
+
+    .masthead h3 {
+        margin-top: 15px;
+        margin-bottom: 5px;
+        font-size: 170%;
+    }
+
+/*--------------------------------------------------------------------------
+  Formatting fsdocs-content
+/*--------------------------------------------------------------------------*/
+
+/* Change font sizes for headings etc. */
+#fsdocs-content h1 {
+    margin: 30px 0px 15px 0px;
+    /* font-weight: 400; */
+    font-size: 2rem;
+    letter-spacing: 1.78px;
+    line-height: 2.5rem;
+    font-weight: 400;
+}
+
+#fsdocs-content h2 {
+    font-size: 1.6rem;
+    margin: 20px 0px 10px 0px;
+    font-weight: 400;
+}
+
+#fsdocs-content h3 {
+    font-size: 1.2rem;
+    margin: 15px 0px 10px 0px;
+    font-weight: 400;
+}
+
+#fsdocs-content hr {
+    margin: 0px 0px 20px 0px;
+}
+
+#fsdocs-content li {
+    font-size: 1.0rem;
+    line-height: 1.375rem;
+    letter-spacing: 0.01px;
+    font-weight: 500;
+    margin: 0px 0px 15px 0px;
+}
+
+#fsdocs-content p {
+    font-size: 1.0rem;
+    line-height: 1.375rem;
+    letter-spacing: 0.01px;
+    font-weight: 500;
+    color: #262626;
+}
+
+#fsdocs-content a {
+    color: #4974D1;
+}
+/* remove the default bootstrap bold on dt elements */
+#fsdocs-content dt {
+    font-weight: normal;
+}
+
+
+
+/*--------------------------------------------------------------------------
+  Formatting tables in fsdocs-content, using docs.microsoft.com tables
+/*--------------------------------------------------------------------------*/
+
+#fsdocs-content .table {
+    table-layout: auto;
+    width: 100%;
+    font-size: 0.875rem;
+}
+
+    #fsdocs-content .table caption {
+        font-size: 0.8rem;
+        font-weight: 600;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        padding: 1.125rem;
+        border-width: 0 0 1px;
+        border-style: solid;
+        border-color: #e3e3e3;
+        text-align: right;
+    }
+
+    #fsdocs-content .table td,
+    #fsdocs-content .table th {
+        display: table-cell;
+        word-wrap: break-word;
+        padding: 0.75rem 1rem 0.75rem 0rem;
+        line-height: 1.5;
+        vertical-align: top;
+        border-top: 1px solid #e3e3e3;
+        border-right: 0;
+        border-left: 0;
+        border-bottom: 0;
+        border-style: solid;
+    }
+
+    /* suppress the top line on inner lists such as tables of exceptions */
+    #fsdocs-content .table .fsdocs-exception-list td,
+    #fsdocs-content .table .fsdocs-exception-list th {
+        border-top: 0
+    }
+
+    #fsdocs-content .table td p:first-child,
+    #fsdocs-content .table th p:first-child {
+        margin-top: 0;
+    }
+
+    #fsdocs-content .table td.nowrap,
+    #fsdocs-content .table th.nowrap {
+        white-space: nowrap;
+    }
+
+    #fsdocs-content .table td.is-narrow,
+    #fsdocs-content .table th.is-narrow {
+        width: 15%;
+    }
+
+    #fsdocs-content .table th:not([scope='row']) {
+        border-top: 0;
+        border-bottom: 1px;
+    }
+
+    #fsdocs-content .table > caption + thead > tr:first-child > td,
+    #fsdocs-content .table > colgroup + thead > tr:first-child > td,
+    #fsdocs-content .table > thead:first-child > tr:first-child > td {
+        border-top: 0;
+    }
+
+    #fsdocs-content .table table-striped > tbody > tr:nth-of-type(odd) {
+        background-color: var(--box-shadow-light);
+    }
+
+    #fsdocs-content .table.min {
+        width: unset;
+    }
+
+    #fsdocs-content .table.is-left-aligned td:first-child,
+    #fsdocs-content .table.is-left-aligned th:first-child {
+        padding-left: 0;
+    }
+
+        #fsdocs-content .table.is-left-aligned td:first-child a,
+        #fsdocs-content .table.is-left-aligned th:first-child a {
+            outline-offset: -0.125rem;
+        }
+
+@media screen and (max-width: 767px), screen and (min-resolution: 120dpi) and (max-width: 767.9px) {
+    #fsdocs-content .table.is-stacked-mobile td:nth-child(1) {
+        display: block;
+        width: 100%;
+        padding: 1rem 0;
+    }
+
+    #fsdocs-content .table.is-stacked-mobile td:not(:nth-child(1)) {
+        display: block;
+        border-width: 0;
+        padding: 0 0 1rem;
+    }
+}
+
+#fsdocs-content .table.has-inner-borders th,
+#fsdocs-content .table.has-inner-borders td {
+    border-right: 1px solid #e3e3e3;
+}
+
+    #fsdocs-content .table.has-inner-borders th:last-child,
+    #fsdocs-content .table.has-inner-borders td:last-child {
+        border-right: none;
+    }
+
+.fsdocs-entity-list .fsdocs-entity-name {
+    width: 25%;
+    font-weight: bold;
+}
+
+.fsdocs-member-list .fsdocs-member-usage {
+    width: 35%;
+}
+
+/*--------------------------------------------------------------------------
+  Formatting xmldoc sections in fsdocs-content
+/*--------------------------------------------------------------------------*/
+
+.fsdocs-xmldoc, .fsdocs-entity-xmldoc, .fsdocs-member-xmldoc {
+    font-size: 1.0rem;
+    line-height: 1.375rem;
+    letter-spacing: 0.01px;
+    font-weight: 500;
+    color: #262626;
+}
+
+.fsdocs-xmldoc h1 {
+    font-size: 1.2rem;
+    margin: 10px 0px 0px 0px;
+}
+
+.fsdocs-xmldoc h2 {
+    font-size: 1.2rem;
+    margin: 10px 0px 0px 0px;
+}
+
+.fsdocs-xmldoc h3 {
+    font-size: 1.1rem;
+    margin: 10px 0px 0px 0px;
+}
+
+/* #fsdocs-nav .searchbox {
+    margin-top: 30px;
+    margin-bottom: 30px;
+} */
+
+#fsdocs-nav img.logo{
+    width:90%;
+    /* height:140px; */
+    /* margin:10px 0px 0px 20px; */
+    margin-top:40px;
+    border-style:none;
+}
+
+#fsdocs-nav input{
+    /* margin-left: 20px; */
+    margin-right: 20px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+    width: 93%;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+}
+
+#fsdocs-nav {
+    /* margin-left: -5px; */
+    /* width: 90%; */
+    font-size:0.95rem;
+}
+
+#fsdocs-nav li.nav-header{
+    /* margin-left: -5px; */
+    /* width: 90%; */
+    padding-left: 0;
+    color: #262626;
+    text-transform: none;
+    font-size:16px;
+    margin-top: 9px;
+    font-weight: bold;
+}
+
+#fsdocs-nav a{
+    padding-left: 0;
+    color: #6c6c6d;
+    /* margin-left: 5px; */
+    /* width: 90%; */
+}
+
+/*--------------------------------------------------------------------------
+  Formatting pre and code sections in fsdocs-content (code highlighting is
+    further below)
+/*--------------------------------------------------------------------------*/
+
+#fsdocs-content code {
+    /* font-size: 0.83rem; */
+    font: 0.85rem 'Roboto Mono', monospace;
+    background-color: #f7f7f900;
+    border: 0px;
+    padding: 0px;
+    /* word-wrap: break-word; */
+    /* white-space: pre; */
+}
+
+/* omitted */
+#fsdocs-content span.omitted {
+    background: #3c4e52;
+    border-radius: 5px;
+    color: #808080;
+    padding: 0px 0px 1px 0px;
+}
+
+#fsdocs-content pre .fssnip code {
+    font: 0.86rem 'Roboto Mono', monospace;
+}
+
+#fsdocs-content table.pre,
+#fsdocs-content pre.fssnip,
+#fsdocs-content pre {
+    line-height: 13pt;
+    border: 0px solid #d8d8d8;
+    border-top: 0px solid #e3e3e3;
+    border-collapse: separate;
+    white-space: pre;
+    font: 0.86rem 'Roboto Mono', monospace;
+    width: 100%;
+    margin: 10px 0px 20px 0px;
+    background-color: #f3f4f7;
+    padding: 10px;
+    border-radius: 5px;
+    color: #8e0e2b;
+    max-width: none;
+    box-sizing: border-box;
+}
+
+#fsdocs-content pre.fssnip code {
+    font: 0.86rem 'Roboto Mono', monospace;
+    font-weight: 600;
+}
+
+#fsdocs-content table.pre {
+    background-color: #fff7ed;
+}
+
+#fsdocs-content table.pre pre {
+    padding: 0px;
+    margin: 0px;
+    border-radius: 0px;
+    width: 100%;
+    background-color: #fff7ed;
+    color: #837b79;
+}
+
+#fsdocs-content table.pre td {
+    padding: 0px;
+    white-space: normal;
+    margin: 0px;
+    width: 100%;
+}
+
+#fsdocs-content table.pre td.lines {
+    width: 30px;
+}
+
+
+#fsdocs-content pre {
+    word-wrap: inherit;
+}
+
+.fsdocs-example-header {
+    font-size: 1.0rem;
+    line-height: 1.375rem;
+    letter-spacing: 0.01px;
+    font-weight: 700;
+    color: #262626;
+}
+
+/*--------------------------------------------------------------------------
+  Formatting github source links
+/*--------------------------------------------------------------------------*/
+
+.fsdocs-source-link {
+    float: right;
+    text-decoration: none;
+}
+
+    .fsdocs-source-link img {
+        border-style: none;
+        margin-left: 10px;
+        width: auto;
+        height: 1.4em;
+    }
+
+    .fsdocs-source-link .hover {
+        display: none;
+    }
+
+    .fsdocs-source-link:hover .hover {
+        display: block;
+    }
+
+    .fsdocs-source-link .normal {
+        display: block;
+    }
+
+    .fsdocs-source-link:hover .normal {
+        display: none;
+    }
+
+/*--------------------------------------------------------------------------
+  Formatting logo
+/*--------------------------------------------------------------------------*/
+
+#fsdocs-logo {
+    width:140px;
+    height:140px;
+    margin:10px 0px 0px 0px;
+    border-style:none;
+}
+
+/*--------------------------------------------------------------------------
+
+/*--------------------------------------------------------------------------*/
+
+#fsdocs-content table.pre pre {
+    padding: 0px;
+    margin: 0px;
+    border: none;
+}
+
+/*--------------------------------------------------------------------------
+  Remove formatting from links
+/*--------------------------------------------------------------------------*/
+
+#fsdocs-content h1 a,
+#fsdocs-content h1 a:hover,
+#fsdocs-content h1 a:focus,
+#fsdocs-content h2 a,
+#fsdocs-content h2 a:hover,
+#fsdocs-content h2 a:focus,
+#fsdocs-content h3 a,
+#fsdocs-content h3 a:hover,
+#fsdocs-content h3 a:focus,
+#fsdocs-content h4 a,
+#fsdocs-content h4 a:hover, #fsdocs-content
+#fsdocs-content h4 a:focus,
+#fsdocs-content h5 a,
+#fsdocs-content h5 a:hover,
+#fsdocs-content h5 a:focus,
+#fsdocs-content h6 a,
+#fsdocs-content h6 a:hover,
+#fsdocs-content h6 a:focus {
+    color: #262626;
+    text-decoration: none;
+    text-decoration-style: none;
+    /* outline: none */
+}
+
+/*--------------------------------------------------------------------------
+  Formatting for F# code snippets
+/*--------------------------------------------------------------------------*/
+
+.fsdocs-param-name,
+.fsdocs-return-name,
+.fsdocs-param {
+    font-weight: 900;
+    font-size: 0.85rem;
+    font-family: 'Roboto Mono', monospace;
+}
+/* strings --- and stlyes for other string related formats */
+#fsdocs-content span.s {
+    color: #dd1144;
+}
+/* printf formatters */
+#fsdocs-content span.pf {
+    color: #E0C57F;
+}
+/* escaped chars */
+#fsdocs-content span.e {
+    color: #EA8675;
+}
+
+/* identifiers --- and styles for more specific identifier types */
+#fsdocs-content span.id {
+    color: #262626;
+}
+/* module */
+#fsdocs-content span.m {
+    color: #009999;
+}
+/* reference type */
+#fsdocs-content span.rt {
+    color: #4974D1;
+}
+/* value type */
+#fsdocs-content span.vt {
+    color: #43AEC6;
+}
+/* interface */
+#fsdocs-content span.if {
+    color: #43AEC6;
+}
+/* type argument */
+#fsdocs-content span.ta {
+    color: #43AEC6;
+}
+/* disposable */
+#fsdocs-content span.d {
+    color: #43AEC6;
+}
+/* property */
+#fsdocs-content span.prop {
+    color: #43AEC6;
+}
+/* punctuation */
+#fsdocs-content span.p {
+    color: #43AEC6;
+}
+#fsdocs-content span.pn {
+    color: #262626;
+}
+/* function */
+#fsdocs-content span.f {
+    color: #e1e1e1;
+}
+#fsdocs-content span.fn {
+    color: #990000;
+}
+/* active pattern */
+#fsdocs-content span.pat {
+    color: #4ec9b0;
+}
+/* union case */
+#fsdocs-content span.u {
+    color: #4ec9b0;
+}
+/* enumeration */
+#fsdocs-content span.e {
+    color: #4ec9b0;
+}
+/* keywords */
+#fsdocs-content span.k {
+    color: #b68015;
+    /* font-weight: bold; */
+}
+/* comment */
+#fsdocs-content span.c {
+    color: #808080;
+    font-weight: 400;
+    font-style: italic;
+}
+/* operators */
+#fsdocs-content span.o {
+    color: #af75c1;
+}
+/* numbers */
+#fsdocs-content span.n {
+    color: #009999;
+}
+/* line number */
+#fsdocs-content span.l {
+    color: #80b0b0;
+}
+/* mutable var or ref cell */
+#fsdocs-content span.v {
+    color: #d1d1d1;
+    font-weight: bold;
+}
+/* inactive code */
+#fsdocs-content span.inactive {
+    color: #808080;
+}
+/* preprocessor */
+#fsdocs-content span.prep {
+    color: #af75c1;
+}
+/* fsi output */
+#fsdocs-content span.fsi {
+    color: #808080;
+}
+
+/* tool tip */
+div.fsdocs-tip {
+    background: #475b5f;
+    border-radius: 4px;
+    font: 0.85rem 'Roboto Mono', monospace;
+    padding: 6px 8px 6px 8px;
+    display: none;
+    color: #d1d1d1;
+    pointer-events: none;
+}
+
+    div.fsdocs-tip code {
+        color: #d1d1d1;
+        font: 0.85rem 'Roboto Mono', monospace;
+    }

--- a/css/main.css
+++ b/css/main.css
@@ -240,12 +240,16 @@ body {
         -webkit-font-smoothing: antialiased;
         font-family: Inter,Arial,sans-serif;
     }
-    
+
     .jumbotron
 
 #jumbotron {
     width: 90%;
     margin: 0 auto;
+    background-image: url(/img/logo/fsharp256.png);
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
 }
 
 #social-btns {
@@ -554,6 +558,27 @@ div#contentMain.testimonials ul li {
     padding: 0px;
 }
 
+.fssnip {
+    text-align:left;
+}
+
+.get-started-separator {
+    display: flex;
+    align-items: center;
+}
+
+.get-started-separator code {
+    font-size: xxx-large;
+    flex-grow: 1;
+    text-align: center;
+    letter-spacing: -7px;
+    color: dodgerblue;
+}
+
+.get-started-header {
+    text-align:center;
+}
+
 /*
 a[href^="http://"]:after, a[href^="https://"]:after {
   content: "\f08e";
@@ -566,11 +591,11 @@ a[href^="http://"]:after, a[href^="https://"]:after {
   padding-left: 7px;
 }
 
-a[href^="https://foundation.fsharp.org"]:after, 
-a[href^="https://fsharp.org"]:after, 
-a[href^="https://github.com/fsharp"]:after, 
-a[href^="https://twitter.com/fsharporg"]:after, 
-a[href^="http://www.facebook.com/fsharp.org"]:after, 
+a[href^="https://foundation.fsharp.org"]:after,
+a[href^="https://fsharp.org"]:after,
+a[href^="https://github.com/fsharp"]:after,
+a[href^="https://twitter.com/fsharporg"]:after,
+a[href^="http://www.facebook.com/fsharp.org"]:after,
 a.no_icon:after {
   content:"" !important;
   padding-left: 0;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -23,21 +24,24 @@
     <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32">
     <meta name="msapplication-TileColor" content="#2d3947">
-    <meta name="msapplication-TileImage" content="/mstile-144x144.png"> 
+    <meta name="msapplication-TileImage" content="/mstile-144x144.png">
 
-    <link href="https://netdna.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" media="screen" />
+    <link href="https://netdna.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet"
+        media="screen" />
     <link href='https://fonts.googleapis.com/css?family=Inter' rel='stylesheet' type='text/css' />
     <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css' />
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <link href="css/animate.css" rel="stylesheet" media="screen" />
     <link href="css/vs.css" rel="stylesheet" media="screen" />
     <link rel="stylesheet" href="css/main.css" media="screen" />
+    <link rel="stylesheet" href="css/fsdocs-default.css" media="screen" />
 
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
 </head>
+
 <body>
     <!-- Navbar -->
     <nav class="navbar navbar-default navbar-fixed-top">
@@ -71,7 +75,8 @@
                                 <a href="https://www.youtube.com/c/fsharporg">Videos (FSSF channel)</a>
                             </li>
                             <li>
-                                <a href="https://www.youtube.com/results?search_query=learn+f%23">Videos (unaffiliated)</a>
+                                <a href="https://www.youtube.com/results?search_query=learn+f%23">Videos
+                                    (unaffiliated)</a>
                             </li>
                         </ul>
                     </li>
@@ -160,10 +165,12 @@
                                 <a href="https://twitter.com/search?q=%23fsharp">F# on Twitter (unaffiliated)</a>
                             </li>
                             <li>
-                                <a href="http://stackoverflow.com/questions/tagged/f%23">F# on StackOverflow (unaffiliated)</a>
+                                <a href="http://stackoverflow.com/questions/tagged/f%23">F# on StackOverflow
+                                    (unaffiliated)</a>
                             </li>
                             <li>
-                                <a href="http://codereview.stackexchange.com/questions/tagged/f%23">F# Code Review (unaffiliated)</a>
+                                <a href="http://codereview.stackexchange.com/questions/tagged/f%23">F# Code Review
+                                    (unaffiliated)</a>
                             </li>
                         </ul>
                     </li>
@@ -205,35 +212,61 @@
     <section class="jumbotron" id="main">
         <div class="container">
             <div class="row" id="jumbotron">
-                <div class="col-md-5 col-md-push-7 text-center">
-                    <div id="logo"><a href="testimonials"><img src="img/logo/fsharp256.png" class="img-responsive img-rounded" alt="F# Logo" /> </a></div>
-                    <div class="btn-group">
-                        <button type="button" class="btn dropdown-toggle btn-menu" data-toggle="dropdown" id="download-btn">
-                            <span class="glyphicon glyphicon-download-alt hidden-xs"></span>
-                            Use F# <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                            <li><a href="use/mac/" onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'mac'])">Mac</a></li>
-                            <li><a href="use/linux/" onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'linux'])">Linux</a></li>
-                            <li><a href="use/windows/" onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'windows'])">Windows</a></li>
-                            <li><a href="use/browser/" onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'browser'])">Browser</a></li>
-                            <li><a href="use/desktop-apps/" onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'desktop'])">Make Desktop Apps</a></li>
-                            <li><a href="use/mobile-apps/" onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'mobile'])">Make Mobile Apps</a></li>
-                            <li><a href="use/notebooks/" onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'jupyter'])">Make Jupyter Notebooks</a></li>
-                            <li><a href="use/web-apps/" onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'browser'])">Make Web Apps</a></li>
-                        </ul>
-                    </div>
-                    <div style="height: 10px;"></div>
-                </div>
-                <div class="col-lg-7 col-md-pull-5">
+                <div class="text-center">
                     <p class="lead">F# empowers everyone to write succinct, robust and performant code</p>
                 </div>
+                <div class="text-center">
+                    <div class="col-md-5">
+                        <button type="button" class="btn dropdown-toggle btn-menu" data-toggle="dropdown" id="download-btn">
+                            <span class="glyphicon glyphicon-download-alt hidden-xs"></span> Get F# <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu" role="menu">
+                            <li><a href="use/mac/"
+                                    onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'mac'])">Mac</a>
+                            </li>
+                            <li><a href="use/linux/"
+                                    onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'linux'])">Linux</a>
+                            </li>
+                            <li><a href="use/windows/"
+                                    onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'windows'])">Windows</a>
+                            </li>
+                            <li><a href="use/browser/"
+                                    onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'browser'])">Browser</a>
+                            </li>
+                            <li><a href="use/desktop-apps/"
+                                    onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'desktop'])">Make
+                                    Desktop Apps</a></li>
+                            <li><a href="use/mobile-apps/"
+                                    onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'mobile'])">Make
+                                    Mobile Apps</a></li>
+                            <li><a href="use/notebooks/"
+                                    onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'jupyter'])">Make
+                                    Jupyter Notebooks</a></li>
+                            <li><a href="use/web-apps/"
+                                    onclick="_gaq.push(['_trackEvent', 'home-use-fsharp', 'clicked', 'browser'])">Make
+                                    Web Apps</a></li>
+                        </ul>
+                    </div>
+                    <div class="col-md-7" id="fsdocs-content">
+                        <pre class="fssnip highlighted"><code lang="fsharp"><span class="k">let</span> <span class="pn">[&lt;</span><span class="rt">Literal</span><span class="pn">&gt;]</span> <span class="prop">DrWho</span> <span class="o">=</span>
+    <span class="s">"https://en.wikipedia.org/wiki/List_of_Doctor_Who_episodes_(1963%E2%80%931989)"</span>
 
-            </div>
+<span class="k">let</span> <span class="id">doctorWho</span> <span class="o">=</span> <span class="k">new</span> <span onmouseout="hideTip(event, 'fs4', 59)" onmouseover="showTip(event, 'fs4', 59)" class="rt">HtmlProvider</span><span class="pn">&lt;</span><span class="prop">DrWho</span><span class="pn">&gt;</span><span class="pn">(</span><span class="pn">)</span>
 
-            <div class="text-center visible-xs" style="margin-top: 20px;">
-                <a href="https://twitter.com/fsharporg" target="_blank" class="btn btn-default btn-circle"><img src="img/Twitter.png" alt="F# Twitter" /></a>
-                <a href="http://www.facebook.com/fsharp.org" target="_blank" class="btn btn-default btn-circle"><img src="img/Facebook.png" alt="F# Facebook" /></a>
+<span class="c">// Get the average number of viewers for each doctor's series run</span>
+<span class="k">let</span> <span class="id">viewersByDoctor</span> <span class="o">=</span>
+    <span class="id">doctorWho</span><span class="pn">.</span><span class="prop">Tables</span><span class="pn">.</span><span class="prop">``Season 1 (1963-1964) Edit``</span><span class="pn">.</span><span class="id">Rows</span>
+    <span class="o">|&gt;</span> <span class="m">Seq</span><span class="pn">.</span><span class="id">groupBy</span> <span class="pn">(</span><span class="k">fun</span> <span class="fn">season</span> <span class="k">-&gt;</span> <span class="fn">season</span><span class="pn">.</span><span class="id">``Directed by``</span><span class="pn">)</span>
+    <span class="o">|&gt;</span> <span class="m">Seq</span><span class="pn">.</span><span class="id">map</span> <span class="pn">(</span><span class="k">fun</span> <span class="pn">(</span><span class="fn">doctor</span><span class="pn">,</span> <span class="fn">seasons</span><span class="pn">)</span> <span class="k">-&gt;</span>
+        <span class="k">let</span> <span class="fn">averaged</span> <span class="o">=</span>
+            <span class="fn">seasons</span>
+            <span class="o">|&gt;</span> <span class="m">Seq</span><span class="pn">.</span><span class="id">averageBy</span> <span class="pn">(</span><span class="k">fun</span> <span class="fn">season</span> <span class="k">-&gt;</span>
+                <span class="fn">season</span><span class="pn">.</span><span class="id">``UK viewers (millions)``</span><span class="pn">)</span>
+            <span class="fn">doctor</span><span class="pn">,</span> <span class="fn">averaged</span><span class="pn">)</span>
+    <span class="o">|&gt;</span> <span class="m">Seq</span><span class="pn">.</span><span class="id">toArray</span>
+                          </code></pre>
+                    </div>
+                </div>
             </div>
         </div>
     </section>
@@ -242,13 +275,22 @@
         <div class="container featured">
             <div class="row">
                 <div class="col-md-4">
-                    <p class="featured">F# gives you <b>simplicity</b> and <b>succinctness</b> like Python with <b>correctness</b>, <b>robustness</b> and <b>performance</b> beyond C# or Java.</p>
+                    <p class="featured">The <b>simplicity</b> and <b>succinctness</b> of Python. <b>Correctness</b> and
+                        <b>performance</b> beyond C# or Java.
+                    </p>
+                    <p class="featured">F# is the best of both worlds.</p>
                 </div>
                 <div class="col-md-4">
-                    <p class="featured">F# is <b>open source</b>, <b>cross-platform</b> and <b>free</b> to use with <b>professional</b> tooling.</p>
+                    <p class="featured"><b>Open source</b>, <b>cross-platform</b>, <b>free to use</b>, and with
+                        <b>professional tooling</b>.
+                    </p>
+                    <p class="featured">F# combines independent with an industry standard experience.</p>
                 </div>
                 <div class="col-md-4">
-                    <p class="featured">F# is a <b>JavaScript</b> and <b>.NET</b> language for <b>web</b>, <b>cloud</b>, <b>data-science</b>, <b>apps</b> and more.</p>
+                    <p class="featured">From <b>Web</b> to <b>Cloud</b>, <b>Data Science</b> to <b>Desktop</b>, and with
+                        <b>Javascript</b> and <b>.NET</b> targeting.
+                    </p>
+                    <p class="featured">F# can be used wherever you need it.</p>
                 </div>
             </div>
         </div>
@@ -257,32 +299,54 @@
     <section class="home-section light-gray">
         <div class="container featured">
             <div class="">
-                <h2 class="text-center section-header">Getting Started</h2>
+                <h2 class="text-center section-header">Start Here</h2>
             </div>
-            <div class="row wow animated fadeIn">
-                <div class="col-md-1">
-                </div>
-                <div class="col-md-5">
-                    <h3><span class="glyphicon glyphicon-pencil"></span> Learn</h3>
+            <div class="row wow animated fadeIn"
+                style="visibility: visible;display: flex;animation-name: fadeIn;">
+
+                <div class="col-md-3">
+                    <h3 class="get-started-header"><span class="glyphicon glyphicon-download"></span> Install the tooling</h3>
                     <ul class="">
-                        <li><a href="https://dotnet.microsoft.com/languages/fsharp"  target="_blank">Why F#?</a></li>
-                        <li><a href="https://dotnet.microsoft.com/languages/fsharp/tools"  target="_blank">Tools for F#</a></li>
-                        <li><a href="use/web-apps/" target="_blank">F# for JavaScript</a></li>
+                        <li><a href="https://dotnet.microsoft.com/download/visual-studio-sdks" target="_blank">.NET
+                                SDK</a></li>
+                        <li><a href="https://code.visualstudio.com/Download" target="_blank">Editor</a></li>
+                        <li><a href="https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp"
+                                target="_blank">F# Extension for VSCode</a></li>
                     </ul>
                 </div>
-                <div class="col-md-5">
-                    <h3><span class="glyphicon glyphicon-user"></span> Community</h3>
+                <div class="col-md-1 get-started-separator">
+                    <div><code class="light-gray">|&gt;</code></div>
+                </div>
+                <div class="col-md-3">
+                    <h3 class="get-started-header"><span class="glyphicon glyphicon-pencil"></span> Learn</h3>
                     <ul>
-                        <li>Join <a href="https://foundation.fsharp.org/join" onclick="_gaq.push(['_trackEvent', 'home-community', 'clicked', 'join'])">the F# Software Foundation</a></li>
-                        <li>Participate on <a href="https://twitter.com/search?q=%23fsharp">Twitter</a></li>
-                        <li>Contribute to <a href="community/projects/" onclick="_gaq.push(['_trackEvent', 'home-community', 'clicked', 'contribute'])">F# projects</a></li>
+                        <li><a href="https://docs.microsoft.com/en-us/dotnet/fsharp/tour?WT.mc_id=dotnet-35129-website"
+                                target="_blank">Language Tour</a></li>
+                        <li><a href="https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/"
+                                target="_blank">Language Reference</a></li>
+                        <li><a href="learn" target="_blank">Explore</a></li>
                     </ul>
                 </div>
-                <div class="col-md-1">
+                <div class="col-md-1 get-started-separator">
+                    <div><code class="light-gray">|&gt;</code></div>
                 </div>
+                <div class="col-md-3">
+                    <h3 class="get-started-header"><span class="glyphicon glyphicon-user"></span> Join Others</h3>
+                    <ul>
+                        <li>Join <a href="https://foundation.fsharp.org/join"
+                                onclick="_gaq.push(['_trackEvent', 'home-community', 'clicked', 'join'])">the F#
+                                Software Foundation</a></li>
+                        <li>Participate on <a href="https://twitter.com/search?q=%23fsharp">Twitter</a></li>
+                        <li>Contribute to <a href="community/projects/"
+                                onclick="_gaq.push(['_trackEvent', 'home-community', 'clicked', 'contribute'])">F#
+                                projects</a></li>
+                    </ul>
+                </div>
+
             </div>
         </div>
     </section>
+
 
     <section class="home-section">
         <div class="container featured">
@@ -292,7 +356,9 @@
                     <div class="col-md-6" id="testimonials-col-1">
                         <blockquote>
                             <p>
-                                <a class="testimonial" href="testimonials/#goswin-1">We see great potential for F# to be used as a scripting language in CAD, it fits very well for computational design challenges in the construction industry.</a>
+                                <a class="testimonial" href="testimonials/#goswin-1">We see great potential for F# to be
+                                    used as a scripting language in CAD, it fits very well for computational design
+                                    challenges in the construction industry.</a>
                             </p>
                             <footer>
                                 <cite><a href="testimonials/#goswin-1" target="_blank">Goswin Rothenthal</a></cite>
@@ -300,71 +366,94 @@
                         </blockquote>
                         <blockquote>
                             <p>
-                                <a class="testimonial" href="testimonials/#simon-cousins-2">I have now delivered three business critical projects written in F#. I am still waiting for the first bug to come in.</a>
-                            </p><footer>
+                                <a class="testimonial" href="testimonials/#simon-cousins-2">I have now delivered three
+                                    business critical projects written in F#. I am still waiting for the first bug to
+                                    come in.</a>
+                            </p>
+                            <footer>
                                 <cite><a href="testimonials/#simon-cousins-2" target="_blank">Simon Cousins</a></cite>
                             </footer>
                         </blockquote>
                         <blockquote>
                             <p>
-                                <a class="testimonial" href="testimonials/#byron-cook-1">F# is the night vision goggles I need when I go into the dark and attempt to solve previously unsolved problems.</a>
-                            </p><footer>
-                                <cite><a href="testimonials/#byron-cook-1" target="_blank">Professor Byron Cook</a></cite>
+                                <a class="testimonial" href="testimonials/#byron-cook-1">F# is the night vision goggles
+                                    I need when I go into the dark and attempt to solve previously unsolved
+                                    problems.</a>
+                            </p>
+                            <footer>
+                                <cite><a href="testimonials/#byron-cook-1" target="_blank">Professor Byron
+                                        Cook</a></cite>
                             </footer>
                         </blockquote>
                     </div>
                     <div class="col-md-6" id="testimonials-col-2">
                         <blockquote>
                             <p>
-                                <a class="testimonial" href="testimonials/#horspool-1">When F# is combined with Visual Studio… productivity goes through the roof!</a>
-                            </p><footer>
+                                <a class="testimonial" href="testimonials/#horspool-1">When F# is combined with Visual
+                                    Studio… productivity goes through the roof!</a>
+                            </p>
+                            <footer>
                                 <cite><a href="testimonials/#horspool-1" target="_blank">Prof Nigel Horspool</a></cite>
                             </footer>
                         </blockquote>
                         <blockquote>
                             <p>
-                                <a class="testimonial" href="testimonials/#michael-hansen">The simple, well-designed and powerful core of the language was perfect for introducing the fundamental concepts of functional programming.</a>
-                            </p><footer>
-                                <cite><a href="testimonials/#michael-hansen" target="_blank">Michael R. Hansen</a></cite>
+                                <a class="testimonial" href="testimonials/#michael-hansen">The simple, well-designed and
+                                    powerful core of the language was perfect for introducing the fundamental concepts
+                                    of functional programming.</a>
+                            </p>
+                            <footer>
+                                <cite><a href="testimonials/#michael-hansen" target="_blank">Michael R.
+                                        Hansen</a></cite>
                             </footer>
                         </blockquote>
                         <blockquote>
                             <p>
-                                <a class="testimonial" href="testimonials/#15below-1">We would recommend F# as an additional tool in the kit of any company building software on the .NET stack.</a>
-                            </p><footer>
+                                <a class="testimonial" href="testimonials/#15below-1">We would recommend F# as an
+                                    additional tool in the kit of any company building software on the .NET stack.</a>
+                            </p>
+                            <footer>
                                 <cite><a href="testimonials/#15below-1" target="_blank">Michael Newton</a></cite>
                             </footer>
                         </blockquote>
                     </div>
                 </div>
-                <a href="testimonials/" class="pull-right" onclick="_gaq.push(['_trackEvent', 'home-testimonials', 'clicked'])">More testimonials &#65125;&#65125;</a>
+                <a href="testimonials/" class="pull-right"
+                    onclick="_gaq.push(['_trackEvent', 'home-testimonials', 'clicked'])">More testimonials
+                    &#65125;&#65125;</a>
             </div>
         </div>
     </section>
 
     <section class="home-section light-gray">
         <div class="container featured">
-            <h2 class="text-center section-header">
-                News<a href="http://fpish.net/rss/blogs/tag/1/f~23" id="news-rss">
-                    <img src="img/rss.png" alt="RSS Feed">
-                </a>
-            </h2>
-            <ul class="list-group wow animated fadeIn animated" id="news-list"></ul>
+            <h2 class="text-center section-header">The Foundation</h2>
+            <p>
+                F# is supported by the F# Software Foundation - an wholly independent non-profit organization which
+                oversees the language design and specification as well as providing community spaces and educational
+                programs for members.
+            </p>
+            <div class="text-center">
+                Learn more and join the community <a href="https://foundation.fsharp.org">here.</a>
+            </div>
+
         </div>
     </section>
 
     <section class="home-section" style="border-bottom: none;">
         <div id="supporter-container" style="display:none;" class="container featured">
-            <h2 class="text-center section-header"><a href="https://foundation.fsharp.org/sponsor_membership" target="_blank">Sponsor Members</a></h2>
+            <h2 class="text-center section-header"><a href="https://foundation.fsharp.org/sponsor_membership"
+                    target="_blank">Sponsor Members</a></h2>
             <div id="sponsors-carousel" class="carousel slide wow animated" data-ride="carousel">
                 <div class="carousel-inner">
                     <div class="item active">
                         <div class="row">
                             <div class="col-md-4">
-                                <img class="center-block img-responsive carousel-img" src="img/sup/fsharpworks.png" alt="fsharpWorks" />
+                                <img class="center-block img-responsive carousel-img" src="img/sup/fsharpworks.png"
+                                    alt="fsharpWorks" />
                             </div>
                             <div class="col-md-4">
-                                <img class="center-block img-responsive carousel-img" src="img/sup/prolucid.png" />                                
+                                <img class="center-block img-responsive carousel-img" src="img/sup/prolucid.png" />
                             </div>
                         </div>
                     </div>
@@ -374,7 +463,7 @@
                                 <img class="center-block img-responsive carousel-img" src="img/sup/genetec.png" />
                             </div>
                             <div class="col-md-4">
-                                <img class="center-block img-responsive carousel-img" src="img/sup/drdispatch.png" />   
+                                <img class="center-block img-responsive carousel-img" src="img/sup/drdispatch.png" />
                             </div>
                         </div>
                     </div>
@@ -391,22 +480,6 @@
         </div>
     </section>
 
-<!--   <section class="home-section" style="border: none;">
-        <div class="container featured">
-            <div class="row wow animated fadeIn">
-                <div class="col-md-2 menu">
-                    <h4>Follow</h4>
-                    <div class="addthis_toolbox addthis_32x32_style addthis_vertical_style">
-                        <a class="addthis_button_facebook_follow" addthis:userid="fsharp.org"></a>
-                        <a class="addthis_button_twitter_follow" addthis:userid="fsharporg"></a>
-                    </div>
-                    <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-54207a8d10b4461b"></script>
-                </div>
-            </div>
-        </div>
-    </section>
-
--->
     <div class="push"></div>
     <div class="push"></div>
 
@@ -415,8 +488,9 @@
         <div class="container text-center">
             <a href="#main" id="footer-arrow"><img src="img/arrow.png" alt="Back to the top" /></a>
             <p>Copyright © 2012-2021 F# Software Foundation and individual contributors.
-            <br/>
-            <p>Maintained by F# Software Foundation and the F# community on <a href="https://github.com/fsharp/fsfoundation" target="_blank">GitHub</a>.</p>
+                <br />
+            <p>Maintained by F# Software Foundation and the F# community on <a
+                    href="https://github.com/fsharp/fsfoundation" target="_blank">GitHub</a>.</p>
         </div>
     </footer>
 
@@ -459,4 +533,5 @@
         })();
     </script>
 </body>
+
 </html>


### PR DESCRIPTION
- Just hijacked the fsdocs default styling, but would probably want to get it cleaner based on the snippets we end up wanting to use.
- Also just borrowed a reasonably verbose sample from FSharp.Data as a fancier ipsum-lorem.
- Ideally, it occurs to me, hooking some highlighting of our key messaging (either across the header and/or across the 3 main-point columns into the snippets could be nice?  Succinct -> here's a cleverly succinct snippet.  Robust?  The same.
- I am no graphic designer, and so getting some slightly more refined pipes between the start-here steps, probably as (background) images would make them more subtle than their current iteration.
- I tweaked the copy of those 3 points to *end* on an `F# (...)` note - my eyes were 'tuning out' those paragraphs because by starting with F#, brain went into memetic-defense mode.  By making a point, and *then* tying back in the name, it seemed to feel more tying things together and ending on the branding.
- Foundation stuff is vaguely place-holder-y, it captures the essence of things, but needs to be made a little more digestible, possibly folding in the sponsor roll into that 'section' instead.


In short:  this is introductory idea stuff, rather than merge-ready PR.  If we like it, let's refine it - if we don't, let's not dump more energy down this path :)