### PR TITLE
improve getting started links

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,8 +265,8 @@
                 <div class="col-md-5">
                     <h3><span class="glyphicon glyphicon-pencil"></span> Learn</h3>
                     <ul class="">
-                        <li><a href="https://dotnet.microsoft.com/languages/fsharp"  target="_blank">Why F#?</a></li>
-                        <li><a href="https://dotnet.microsoft.com/languages/fsharp/tools"  target="_blank">Tools for F#</a></li>
+                        <li><a href="https://dotnet.microsoft.com/learn/languages/fsharp-hello-world-tutorial"  target="_blank">Hello World</a></li>
+                        <li><a href="https://www.youtube.com/playlist?list=PLdo4fOcmZ0oUFghYOp89baYFBTGxUkC7Z"  target="_blank">F# for Beginners</a></li>
                         <li><a href="use/web-apps/" target="_blank">F# for JavaScript</a></li>
                     </ul>
                 </div>

--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
                 <div class="col-md-5">
                     <h3><span class="glyphicon glyphicon-pencil"></span> Learn</h3>
                     <ul class="">
-                        <li><a href="https://dotnet.microsoft.com/learn/languages/fsharp-hello-world-tutorial"  target="_blank">Hello World</a></li>
+                        <li><a href="https://dotnet.microsoft.com/learn/languages/fsharp-hello-world-tutorial"  target="_blank">F# Hello World in 5min</a></li>
                         <li><a href="https://www.youtube.com/playlist?list=PLdo4fOcmZ0oUFghYOp89baYFBTGxUkC7Z"  target="_blank">F# for Beginners</a></li>
                         <li><a href="use/web-apps/" target="_blank">F# for JavaScript</a></li>
                     </ul>


### PR DESCRIPTION

At last Dugnad (a long time ago) it was pointed out that the "Getting Started" section was weak, in that it didn't give links to actually get started.

This improves that by making the first two links actual intro tutorials

The "F# for JavaScript" link remains as https://fsharp.org is an asset that emphasises this.
