### PR TITLE
Replace Kafunk with FsKafka

### DIFF
--- a/guides/cloud/index.md
+++ b/guides/cloud/index.md
@@ -84,7 +84,7 @@ The [Orleans](https://dotnet.github.io/orleans/) framework provides a straightfo
 
 #### Kafka
 
-* [Kafunk](https://jet.github.io/kafunk/) - An F# Kafka client.
+* [FsKafka](https://jet.github.io/FsKafka/) - An F# Kafka client.
 
 * [anaerobic](https://github.com/anaerobic/fsharp-kafka-simple) - A simple implementation of a Kafka producer and consumer in F#.
 


### PR DESCRIPTION
FsKafka is the de facto successor to Kafunk

it's a light weight F#-focused wrapper over a supported mainstream library (`Confluent.Kafka`) and is being used and maintained.

Kafunk is an archived and unmaintained top to bottom custom client which has some known issues, but also, critically, does not support modern broker versions.