### PR TITLE
Don't suggest the install-scripts for linux

### DIFF
--- a/use/linux/index.md
+++ b/use/linux/index.md
@@ -8,19 +8,6 @@ headline: Use F# on Linux
 
 ![logo](../../images/thumbs/dotnet.png)&nbsp;Install the [.NET SDK](https://dotnet.microsoft.com/download). .NET is available for major Linux distributions and is typically installed with the system package manager of your distribution of choice.
 
-Use this one-liner to acquire an installation script if that's your preference:
-
-```
-curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version latest
-```
-
-Configure environment variables for your preferred shell profile (i.e. *~/.bashrc*).
-
-```
-export DOTNET_ROOT=$HOME/.dotnet
-export PATH=$PATH:$HOME/.dotnet:$HOME/.dotnet/tools
-```
-
 Once that is installed, you can begin using F#!
 
 Create a file called `hello.fsx` that looks like this:


### PR DESCRIPTION
This is a foot-gun - the install docs on learn.ms.com are more comprehensive and we _really_ do not want users installing local versions of the SDK. It's inconsistent in a lot of small ways that I have to wrestle with day-to-day. Since the SDK is available in many package managers now by default we should lean into that mechanism.