### PR TITLE
Update index.md to not suggest install-sh for mac

### DIFF
--- a/use/mac/index.md
+++ b/use/mac/index.md
@@ -8,19 +8,6 @@ headline: Use F# on macOS
 
 ![logo](../../images/thumbs/dotnet.png)&nbsp;Install the [.NET SDK](https://dotnet.microsoft.com/download).
 
-You can also use this one-liner from the command-line if you prefer not to use the installer package:
-
-```
-curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version latest
-```
-
-Configure environment variables for your preferred shell profile (i.e. *~/.bashrc*).
-
-```
-export DOTNET_ROOT=$HOME/.dotnet
-export PATH=$PATH:$HOME/.dotnet:$HOME/.dotnet/tools
-```
-
 Once that is installed, you can begin using F#!
 
 Create a file called `hello.fsx` that looks like this:


### PR DESCRIPTION
This is a foot-gun - the install docs on learn.ms.com are more comprehensive and we _really_ do not want users installing local versions of the SDK. It's inconsistent in a lot of small ways that I have to wrestle with day-to-day. If we did want to highlight CLI-based installs I'd rather suggest homebrew (even though the homebrew recipe is horrible because it doesn't support side-by-side).