### PR TITLE
Add dynamic copyright to html template

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -217,7 +217,7 @@
     <!-- Footer -->
     <footer id="footer">
         <div class="container text-center">
-            <p>Copyright © 2012-2020 F# Software Foundation and individual contributors.
+            <p>Copyright © 2012-<span id="copyright-year">2023</span> F# Software Foundation and individual contributors.
             <br/>
             <p>Maintained by F# Software Foundation and the F# community on <a href="https://github.com/fsharp/fsfoundation" target="_blank">GitHub</a>.</p>
         </div>
@@ -252,6 +252,9 @@
 
         ga('create', 'UA-35753329-2', 'auto');
         ga('send', 'pageview');
+    </script>
+    <script>
+        $('#copyright-year').html(new Date().getFullYear());
     </script>
 </body>
 </html>


### PR DESCRIPTION
Fixed the template as well. So the other pages also get a more correct copyright year.

Should have noticed this and included it with the other PR 
