### PR TITLE
Update link to F# Cheat Sheet

### DIFF
--- a/learn/index.md
+++ b/learn/index.md
@@ -35,7 +35,7 @@ Whether it's your first programming language or your next, F# will transform you
 Introduces you to F# and show you ways that F# can help in day-to-day development
 of mainstream commercial business software.
 
-### [F# Cheat Sheet](http://dungpa.github.io/fsharp-cheatsheet/)
+### [F# Cheat Sheet](http://fsprojects.github.io/fsharp-cheatsheet/)
 
 <img src="../images/thumbs/cheetsheet.png" style="float:right;margin:5px 0px 5px 25px;" />
 


### PR DESCRIPTION
Updated the link of the heading to point to http://fsprojects.github.io/fsharp-cheatsheet/