### PR TITLE
Documentation - Update cheat sheet links to working links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,11 +25,11 @@ headline: Documentation for F#
 
 <br />
 
-## [F# Cheat Sheet](http://dungpa.github.io/fsharp-cheatsheet/)
+## [F# Cheat Sheet](https://github.com/fsprojects/fsharp-cheatsheet)
 
 <img src="../images/thumbs/cheetsheet.png" style="float:right;margin:5px 0px 5px 25px;" />
 
-* The cheat sheet is a small and concise guide to F# syntax for newcomers to get started with the language. It's available in [HTML](http://dungpa.github.io/fsharp-cheatsheet/) and [PDF](https://github.com/dungpa/fsharp-cheatsheet/raw/gh-pages/fsharp-cheatsheet.pdf) format.
+* The cheat sheet is a small and concise guide to F# syntax for newcomers to get started with the language. It's available in [HTML](https://fsprojects.github.io/fsharp-cheatsheet/) and [PDF](https://fsprojects.github.io/fsharp-cheatsheet/fsharp-cheatsheet.pdf) format.
 
 <br />
 


### PR DESCRIPTION
http://dungpa.github.io/fsharp-cheatsheet/ was returning a 404 Not Found. 

![image](https://github.com/fsharp/fsfoundation/assets/29626438/91e1cc85-e590-482f-8a8b-31cc31aa4999)



I have updated the links for the cheat sheet section to be the correct links 

![image](https://github.com/fsharp/fsfoundation/assets/29626438/b8a5cb7c-5e8b-4405-a92e-ac7d3df8ccf9)

![image](https://github.com/fsharp/fsfoundation/assets/29626438/3541c93b-0a73-42b8-adaa-ec01f8dae87d)
